### PR TITLE
Socket delivery: fix race condition that might crash the manager.

### DIFF
--- a/src/lhttpc_sock.erl
+++ b/src/lhttpc_sock.erl
@@ -129,7 +129,7 @@ send(Socket, Request, false) ->
     gen_tcp:send(Socket, Request).
 
 %%------------------------------------------------------------------------------
-%% @spec (Socket, Process, SslFlag) -> ok | {error, Reason}
+%% @spec (Socket, Process, SslFlag) -> {ok, pid()} | {error, Reason}
 %%   Socket = socket()
 %%   Process = pid() | atom()
 %%   SslFlag = boolean()
@@ -139,13 +139,19 @@ send(Socket, Request, false) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec controlling_process(socket(), pid() | atom(), boolean()) ->
-    ok | {error, atom()}.
+    {ok, pid()} | {error, atom()}.
 controlling_process(Socket, Controller, IsSsl) when is_atom(Controller) ->
     controlling_process(Socket, whereis(Controller), IsSsl);
 controlling_process(Socket, Pid, true) ->
-    ssl:controlling_process(Socket, Pid);
+    case ssl:controlling_process(Socket, Pid) of
+        ok  -> {ok, Pid};
+        Err -> Err
+    end;
 controlling_process(Socket, Pid, false) ->
-    gen_tcp:controlling_process(Socket, Pid).
+    case gen_tcp:controlling_process(Socket, Pid) of
+        ok  -> {ok, Pid};
+        Err -> Err
+    end.
 
 %%------------------------------------------------------------------------------
 %% @spec (Socket, Options, SslFlag) -> ok | {error, Reason}

--- a/test/lhttpc_manager_tests.erl
+++ b/test/lhttpc_manager_tests.erl
@@ -37,6 +37,8 @@
 %%% Eunit setup stuff
 
 start_app() ->
+    application:start(asn1),
+    application:start(crypto),
     application:start(public_key),
     ok = application:start(ssl),
     _ = application:load(lhttpc),

--- a/test/lhttpc_tests.erl
+++ b/test/lhttpc_tests.erl
@@ -100,6 +100,7 @@ test_no(N, Tests) ->
 %%% Eunit setup stuff
 
 start_app() ->
+    application:start(asn1),
     application:start(crypto),
     application:start(public_key),
     ok = application:start(ssl),


### PR DESCRIPTION
When dealing with short-lived, high-rate requests, an unexpected manager death will result in cascade failure that ends up crashing the node when using the default MaxR/MaxT values for lhttpc_sup (10 restarts per sec.)

This is due to a sneaky race condition on lhttpc_manager:client_done/5. Between confirming that our pool is the current socket owner (lhttpc_sock:controlling_process/3) and actually delivering the socket back (gen_server:call/3 with 'DoneMsg') the manager might die and be restarted. If this happens, the delivery handling on lhttpc_manager will crash on 'dict:fetch/2' because this is a new manager and as such it has no idea about who the caller is.

'lhttpc_sock:controlling_process/3' now returns the resolved Pid so that we can be sure we're always calling the appropriate process (and, in case of sudden death, making sure there's no resource leakage)